### PR TITLE
finish factorialIncr proof

### DIFF
--- a/Control/Permutation/Proofs.idr
+++ b/Control/Permutation/Proofs.idr
@@ -9,7 +9,7 @@ import Control.Permutation.Mod
 ||| Proof that (n + 1)! >= n!
 factorialIncr : (n : Nat) -> LTE (factorial n) (factorial (S n))
 factorialIncr Z = lteRefl
-factorialIncr n = ?idk_hole
+factorialIncr n = lteAddRight (factorial n)
 
 ||| Proof that n! >= 1
 factorialLTE : (n : Nat) -> LTE 1 (factorial n)

--- a/Control/Permutation/Proofs.idr
+++ b/Control/Permutation/Proofs.idr
@@ -3,7 +3,7 @@ module Control.Permutation.Proofs
 import Control.Permutation.Types
 import Control.Permutation.Mod
 
-%access public export
+%access export
 %default total
 
 ||| Proof that (n + 1)! >= n!


### PR DESCRIPTION
Also don't export proof bodies - usually just the type is enough for proofs, and less exports allegedly help with compile times.